### PR TITLE
Added Optional argument and fix branch length

### DIFF
--- a/commands/pr.js
+++ b/commands/pr.js
@@ -36,7 +36,9 @@ const pr = async (jiraUrl, newBranchName) => {
     const { fields: { summary = "" } = {}, key = "" } = issueDetails; // get relevant fields
 
     //passing the optional branch name if it exists.
-    const branchName = newBranchName ? newBranchName : branchify(key, summary);
+    const branchName = newBranchName
+      ? newBranchName.slice(0, 25) // Trim newBranchName if it exceeds 25 characters
+      : branchify(key, summary);
 
     const onClean = await onCleanBranch();
     if (!onClean) return;

--- a/commands/pr.js
+++ b/commands/pr.js
@@ -37,7 +37,7 @@ const pr = async (jiraUrl, newBranchName) => {
 
     //passing the optional branch name if it exists.
     const branchName = newBranchName
-      ? newBranchName.slice(0, 30) // Trim newBranchName if it exceeds 30 characters
+      ? branchify(newBranchName)
       : branchify(key, summary);
 
     const onClean = await onCleanBranch();

--- a/commands/pr.js
+++ b/commands/pr.js
@@ -37,7 +37,7 @@ const pr = async (jiraUrl, newBranchName) => {
 
     //passing the optional branch name if it exists.
     const branchName = newBranchName
-      ? newBranchName.slice(0, 25) // Trim newBranchName if it exceeds 25 characters
+      ? newBranchName.slice(0, 30) // Trim newBranchName if it exceeds 30 characters
       : branchify(key, summary);
 
     const onClean = await onCleanBranch();

--- a/commands/pr.js
+++ b/commands/pr.js
@@ -15,7 +15,7 @@ const {
   fetchIssueDetailsFromJira,
 } = require("../utils/http");
 
-const pr = async (jiraUrl) => {
+const pr = async (jiraUrl, newBranchName) => {
   try {
     const environmentVariables = getEnvVariables();
     const jiraKey = getJiraIssueKeyFromUrl(jiraUrl);
@@ -34,7 +34,9 @@ const pr = async (jiraUrl) => {
     }
 
     const { fields: { summary = "" } = {}, key = "" } = issueDetails; // get relevant fields
-    const branchName = branchify(key, summary);
+
+    //passing the optional branch name if it exists.
+    const branchName = newBranchName ? newBranchName : branchify(key, summary);
 
     const onClean = await onCleanBranch();
     if (!onClean) return;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ const pr = require("./commands/pr");
 program
   .name("pfi")
   .description("Creates a new Pull Request when given a Jira Issue URL")
-  .arguments("<string>", "Jira Issue URL")
-  .action(pr);
+  .arguments("<jiraUrl> [newBranchName]") // Updated to include optional branch name
+  .action((jiraUrl, newBranchName) => {
+    pr(jiraUrl, newBranchName); // Pass both arguments to the `pr` function
+  });
 
 program.parse();

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -1,7 +1,7 @@
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 
-const branchify = (key, summary) => {
+const branchify = (key, summary = "") => {
   const lowerKey = String(key).toLowerCase().split(" ").join("-");
   const lowerSummary = String(summary).toLowerCase().split(" ").join("-");
 

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -7,7 +7,7 @@ const branchify = (key, summary) => {
 
   return `${lowerKey}-${lowerSummary}`
     .replace(/[^a-z0-9-]/g, "") // removes anything that is not alphanumeric or a hyphen
-    .slice(0, 25) // max length 25 characters for branch, to avoid invalid deployed URL
+    .slice(0, 30) // max length 30 characters for branch, to avoid invalid deployed URL
     .trim(); // remove whitespace
 };
 

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -7,7 +7,7 @@ const branchify = (key, summary) => {
 
   return `${lowerKey}-${lowerSummary}`
     .replace(/[^a-z0-9-]/g, "") // removes anything that is not alphanumeric or a hyphen
-    .slice(0, 50) // max length 50 characters for branch
+    .slice(0, 25) // max length 25 characters for branch, to avoid invalid deployed URL
     .trim(); // remove whitespace
 };
 


### PR DESCRIPTION
**Issue**: The purpose of this PR is to resolve an issue where the branch names were too long, resulting in the generated deployed URLs being invalid.

**This code**:
- adds an optional `newBranchName` argument.
- reduces the branchName length to 30 characters to avoid invalid deployed URL in case the optional argument is not passed.

**Sample PRs**(closed the PRs to avoid confusion with the current sprint):
1. With optional argument: 
**Command:** `pfi https://evertroops.atlassian.net/browse/ET-25941 et-25941-fix-actions-menu`
**PR:** https://github.com/evertrue/givingtree-web/pull/3954
2. Without optional argument: 
**Command:** `pfi https://evertroops.atlassian.net/browse/ET-25941`
**PR:** https://github.com/evertrue/givingtree-web/pull/3953